### PR TITLE
Remove ExCrypto dependency

### DIFF
--- a/lib/encrypted_secrets/encryption.ex
+++ b/lib/encrypted_secrets/encryption.ex
@@ -19,7 +19,7 @@ defmodule EncryptedSecrets.Encryption do
   end
 
   @doc """
-    Encrypts `clear_text` using the given key
+    Encrypts `clear_text` using the given `key`
   """
   def encrypt(key, clear_text) do
     init_vec = :crypto.strong_rand_bytes(16)
@@ -38,6 +38,9 @@ defmodule EncryptedSecrets.Encryption do
     end
   end
 
+  @doc """
+    Encrypts `cipher_text` using the given `key` and `init_vec`
+  """
   def decrypt(key, init_vec, cipher_text) do
     case :crypto.block_decrypt(:aes_cbc256, key, init_vec, cipher_text) do
       :error -> {:error, :decrypt_failed}

--- a/lib/encrypted_secrets/encryption.ex
+++ b/lib/encrypted_secrets/encryption.ex
@@ -3,7 +3,43 @@ defmodule EncryptedSecrets.Encryption do
     Provides methods for reading creating keys and encrypting/decrypting payloads
   """
 
+  @aes_block_size 16
+
+  @doc """
+    Generates a 256 bit (32 byte) random key to be used as the master key
+
+  ## Examples
+      iex> binary_key = Encryption.generate_aes_key()
+      iex> random_string = binary_key |> Base.encode16
+      iex> String.length(random_string)
+      64
+  """
   def generate_aes_key() do
     :crypto.strong_rand_bytes(32)
+  end
+
+  @doc """
+    Encrypts `clear_text` using the given key
+  """
+  def encrypt(key, clear_text) do
+    initialization_vector = :crypto.strong_rand_bytes(16)
+    payload = pad(clear_text, @aes_block_size)
+
+    case :crypto.block_encrypt(:aes_cbc256, key, initialization_vector, payload) do
+      {cipher_text, cipher_tag} ->
+        {authentication_data, _clear_text} = payload
+        {:ok, {authentication_data, {initialization_vector, cipher_text, cipher_tag}}}
+
+      <<cipher_text::binary>> ->
+        {:ok, {initialization_vector, cipher_text}}
+
+      err ->
+        {:error, err}
+    end
+  end
+
+  defp pad(data, block_size) do
+    to_add = block_size - rem(byte_size(data), block_size)
+    data <> to_string(:string.chars(to_add, to_add))
   end
 end

--- a/lib/encrypted_secrets/encryption.ex
+++ b/lib/encrypted_secrets/encryption.ex
@@ -1,0 +1,9 @@
+defmodule EncryptedSecrets.Encryption do
+  @moduledoc """
+    Provides methods for reading creating keys and encrypting/decrypting payloads
+  """
+
+  def generate_aes_key() do
+    :crypto.strong_rand_bytes(32)
+  end
+end

--- a/lib/encrypted_secrets/master_key.ex
+++ b/lib/encrypted_secrets/master_key.ex
@@ -3,6 +3,8 @@ defmodule EncryptedSecrets.MasterKey do
     Provides a method for creating and saving a random master encryption key
   """
 
+  alias EncryptedSecrets.Encryption, as: Encryption
+
   @doc """
     Creates a random key and saves it to the specified `filepath`
 
@@ -16,9 +18,8 @@ defmodule EncryptedSecrets.MasterKey do
   end
 
   defp create_random_key do
-    {:ok, key} = ExCrypto.generate_aes_key(:aes_256, :bytes)
-
-    Base.encode16(key)
+    Encryption.generate_aes_key()
+    |> Base.encode16()
   end
 
   defp save_master_key(key, output_path) do

--- a/lib/encrypted_secrets/read_secrets.ex
+++ b/lib/encrypted_secrets/read_secrets.ex
@@ -4,6 +4,7 @@ defmodule EncryptedSecrets.ReadSecrets do
   """
 
   alias EncryptedSecrets.Helpers, as: Helpers
+  alias EncryptedSecrets.Encryption, as: Encryption
 
   @doc """
     Reads encrypted secrets file at `input_path` using `key`, returning a map
@@ -47,7 +48,7 @@ defmodule EncryptedSecrets.ReadSecrets do
       String.split(input_text, "|")
       |> Enum.map(&Base.decode16!/1)
 
-    case ExCrypto.decrypt(Base.decode16!(key), init_vec, cipher_text) do
+    case Encryption.decrypt(Base.decode16!(key), init_vec, cipher_text) do
       {:ok, contents} -> contents
       {:error, err} -> raise "Error decrypting secrets (#{err})"
     end

--- a/lib/encrypted_secrets/write_secrets.ex
+++ b/lib/encrypted_secrets/write_secrets.ex
@@ -3,6 +3,8 @@ defmodule EncryptedSecrets.WriteSecrets do
     Provides a method for reading a file then writing it as an encrypted string
   """
 
+  alias EncryptedSecrets.Encryption, as: Encryption
+
   @doc """
     Reads the contents of `input_path`, encrypts it using `key`,
      and writes it to `output_path`
@@ -42,7 +44,7 @@ defmodule EncryptedSecrets.WriteSecrets do
   defp encrypt_message(input_text, key) do
     {:ok, {init_vec, cipher_text}} =
       Base.decode16!(key)
-      |> ExCrypto.encrypt(input_text)
+      |> Encryption.encrypt(input_text)
 
     {Base.encode16(init_vec), Base.encode16(cipher_text)}
   end

--- a/lib/mix/tasks/encrypted_secrets/setup.ex
+++ b/lib/mix/tasks/encrypted_secrets/setup.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.EncryptedSecrets.Setup do
   use Mix.Task
 
   @doc """
-    "Creates key and secrets file in config/"
+    "Creates key and secrets file in config/secrets/"
   """
   def run(_) do
     case EncryptedSecrets.setup() do

--- a/mix.exs
+++ b/mix.exs
@@ -23,8 +23,7 @@ defmodule EncryptedSecrets.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.12"},
-      {:yaml_elixir, "~> 2.1.0"},
-      {:ex_crypto, "~> 0.10.0"}
+      {:yaml_elixir, "~> 2.1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,9 @@
 %{
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_crypto": {:hex, :ex_crypto, "0.10.0", "af600a89b784b36613a989da6e998c1b200ff1214c3cfbaf8deca4aa2f0a1739", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
   "yamerl": {:hex, :yamerl, "0.7.0", "e51dba652dce74c20a88294130b48051ebbbb0be7d76f22de064f0f3ccf0aaf5", [:rebar3], [], "hexpm"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.1.0", "79ec163e0f379dadf4b0e8b5162567dc1feb96c3cfa793105869e2c616ab4342", [:mix], [{:yamerl, "~> 0.7", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/encrypted_secrets/encryption_test.exs
+++ b/test/encrypted_secrets/encryption_test.exs
@@ -1,0 +1,5 @@
+defmodule EncryptedSecretsTest.EncryptionTest do
+  use ExUnit.Case
+  alias EncryptedSecrets.Encryption, as: Encryption
+  doctest EncryptedSecrets.Encryption
+end

--- a/test/encrypted_secrets/encryption_test.exs
+++ b/test/encrypted_secrets/encryption_test.exs
@@ -2,4 +2,23 @@ defmodule EncryptedSecretsTest.EncryptionTest do
   use ExUnit.Case
   alias EncryptedSecrets.Encryption, as: Encryption
   doctest EncryptedSecrets.Encryption
+
+  test "generate 256 bit AES key as bytes" do
+    aes_256_key = Encryption.generate_aes_key()
+
+    assert(Kernel.is_bitstring(aes_256_key))
+    assert(byte_size(aes_256_key) == 32)
+    assert(bit_size(aes_256_key) == 256)
+  end
+
+  test "aes_gcm round-trip with 256 bit key" do
+    aes_256_key = Encryption.generate_aes_key()
+    clear_text = "a very secret message"
+
+    {:ok, {init_vec, cipher_text}} = Encryption.encrypt(aes_256_key, clear_text)
+    assert(clear_text != cipher_text)
+
+    {:ok, decrypted_clear_text} = Encryption.decrypt(aes_256_key, init_vec, cipher_text)
+    assert(decrypted_clear_text == clear_text)
+  end
 end


### PR DESCRIPTION
Solves #3 

Removes ExCrypto, increasing visibility into the encryption scheme and removing the dependence on a third-party