### PR TITLE
Fix EDITOR args splitting

### DIFF
--- a/lib/encrypted_secrets.ex
+++ b/lib/encrypted_secrets.ex
@@ -10,6 +10,7 @@ defmodule EncryptedSecrets do
   @base_directory "priv/secrets"
   @secrets_file_location @base_directory <> "/secrets.yml.enc"
   @key_file_location @base_directory <> "/master.key"
+  @editor_args_regex ~r/ (-\w{2,}|-\w\s+"(?:[^"\\]*(?:\\.[^"\\]*)*)"|-\w\s+'(?:[^'\\]*(?:\\.[^'\\]*)*)'|--\w+="(?:[^"\\]*(?:\\.[^"\\]*)*)"|--\w+='(?:[^'\\]*(?:\\.[^'\\]*)*)'|--\w+=[^\s]+|-\w)/
 
   @doc """
     Creates a new key and secrets file, prompting you if the files already exist
@@ -59,7 +60,13 @@ defmodule EncryptedSecrets do
 
     case ReadSecrets.read_into_file(key, secrets_path) do
       {:ok, tmp_filepath} ->
-        [editor | options] = String.split(System.get_env("EDITOR"), " ")
+        [editor | options] = String.split(
+          System.get_env("EDITOR"),
+          @editor_args_regex,
+          include_captures: true,
+          trim: true
+        )
+        options = Enum.map(options, &String.trim/1)
         {_retval, 0} = System.cmd(editor, options ++ [tmp_filepath])
 
         case WriteSecrets.write_file(key, tmp_filepath, secrets_path) do


### PR DESCRIPTION
When supplying arguments with values to the system EDITOR the System.cmd call
would fail as the options are incorrect.
e.g. `EDITOR='mvim -f -c "au VimLeave * !open -a iTerm"'` would be split into `["-f", "-c", "\"au", "VimLeave"...]` which is obviously incorrect

This adds a more robust regex based delimiter to split the EDITOR command. 

Allows all of these arg types
`editor -c -stacked -z "with value" --named=no-quotes --with="quotes"`
Also allows strings with escaped quotes and single quotes

Fixes #7 