### PR TITLE
Remove tmp files when editing process is killed

### DIFF
--- a/priv/tmp_file_cleaner.sh
+++ b/priv/tmp_file_cleaner.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+while read line; do
+  :
+done
+
+rm -f $1


### PR DESCRIPTION
Closes #1 by running a shell script in the background that removes tmp file when a process is killed.