### PR TITLE
Update :crypto Functions to New API for Erlang 24

### DIFF
--- a/lib/encrypted_secrets/encryption.ex
+++ b/lib/encrypted_secrets/encryption.ex
@@ -25,7 +25,7 @@ defmodule EncryptedSecrets.Encryption do
     init_vec = :crypto.strong_rand_bytes(16)
     payload = pad(clear_text, @aes_block_size)
 
-    case :crypto.block_encrypt(:aes_cbc256, key, init_vec, payload) do
+    case :crypto.crypto_one_time(:aes_256_cbc, key, init_vec, payload, true) do
       {cipher_text, cipher_tag} ->
         {authentication_data, _clear_text} = payload
         {:ok, {authentication_data, {init_vec, cipher_text, cipher_tag}}}
@@ -42,7 +42,7 @@ defmodule EncryptedSecrets.Encryption do
     Decrypts `cipher_text` using the given `key` and `init_vec`
   """
   def decrypt(key, init_vec, cipher_text) do
-    case :crypto.block_decrypt(:aes_cbc256, key, init_vec, cipher_text) do
+    case :crypto.crypto_one_time(:aes_256_cbc, key, init_vec, cipher_text, false) do
       :error -> {:error, :decrypt_failed}
       plain_text -> {:ok, unpad(plain_text)}
     end


### PR DESCRIPTION
`:crypto.block_encrypt` and `:crypto.block_decrypt` are now deprecated.

More info here:
https://erlang.org/doc/apps/crypto/new_api.html